### PR TITLE
set version by git tag, not constant value

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.1.0-alpha
+VERSION := $(shell git describe --tag)
 
 .PHONY:
 
@@ -28,7 +28,7 @@ build-simple: clean
 	go1.16beta1 build \
 		-o dist/pcopy_linux_amd64/pcopy \
 		-ldflags \
-		"-X main.version=${VERSION} -X main.commit=$(shell git rev-parse --short HEAD) -X main.date=$(shell date +%s)" \
+		"-s -w -X main.version=$(VERSION) -X main.commit=$(shell git rev-parse --short HEAD) -X main.date=$(shell date +%s)" \
 		cmd/pcopy/*.go
 
 release:


### PR DESCRIPTION
Hi binwiederhier:

1. I noticed in [Makefile](https://github.com/binwiederhier/pcopy/blob/2dc3f8b49830915bb9bdd3ab1d58d9ba408ab2b3/Makefile#L1), VERSION was set to 0.1.0-alpha, it won't change as the git tag changes

2.  I add `-ldflags "-s -w"`, as the [GoDoc](https://golang.org/cmd/link/) says:

```sh
-s
	Omit the symbol table and debug information.
-w
	Omit the DWARF symbol table.
```
this should work, causing I'm using `go version go1.15.2 windows/amd64`,  the [embed](https://github.com/binwiederhier/pcopy/blob/2dc3f8b498/config.go#L5) was support in [go1.16beta1](https://github.com/golang/go/commit/25d28ec55aded46e0be9c2298f24287d296a9e47), and in [go download page](https://golang.org/dl/) It was not publicly released until now, so I can't verify this on my machine.





